### PR TITLE
Use different horizons for different frequency series

### DIFF
--- a/dash/pages_static.py
+++ b/dash/pages_static.py
@@ -22,7 +22,8 @@ The available models are listed in the [Leaderboard](/leaderboard/).
 These are based on the benchmark models used in the M4 Competition \[0\].
 
 The models are run on each dataset according to the time series cross-validation
-scheme described in \[1\], Sect 3.4, with forecast horizons of length 1-8.
+scheme described in \[1\], Sect 3.4. The forecast horizon depends upon the frequency of the 
+underlying time series, that is 6 for yearly, 8 for quarterly and 18 for monthly data. 
 
 ![time series cross-validation](https://otexts.com/fpp2/fpp_files/figure-html/cv1-1.png)
 \(Image reproduced from \[1\] with permission.\)

--- a/updater/models.py
+++ b/updater/models.py
@@ -16,6 +16,8 @@ from keras.models import Sequential
 from keras.layers import Dense, SimpleRNN
 from tensorflow.keras.optimizers import RMSprop
 
+import warnings
+
 ### functions for the MLP and RNN models ###
 def split_into_train(y, lags):
     """
@@ -128,9 +130,10 @@ def remove_seasonality(y, h, period):
 
 
 class ForecastModel(BaseEstimator, ABC):
-    def __init__(self, h=None, level=None):
+    def __init__(self, h=None, level=None, period=None):
         self.h = h
         self.level = level
+        self.period = period
 
     @property
     @staticmethod
@@ -159,9 +162,9 @@ class MLP_M4_benchmark(ForecastModel):
     name = "MLP"
     method = "MLP M4 Competition Benchmark"
 
-    def __init__(self, h=1, level=[]):
+    def __init__(self, h=1, level=[], period=None):
         self.input_size = 3  # number of inputs to the forecasting model (lags of the time series)
-        super().__init__(h, level)
+        super().__init__(h, level, period)
 
     def description(self):
         return self.method
@@ -170,27 +173,24 @@ class MLP_M4_benchmark(ForecastModel):
         self.y = y
         self.y_tilde = y.copy()  # detrended and de-seasonalized copy of y
 
-        # Find period of y
-        freq = getattr(self.y.index, "inferred_freq", None)
-        self.period = freq_to_period(freq)
-
         # detrending
         self.a, self.b = detrend(self.y.values)
         for i in range(len(y)):
             self.y_tilde[i] = self.y_tilde[i] - ((self.a * i) + self.b)
 
         self.seasonal_bool = False
-        if (
-            (seasonality_test(self.y, self.period))
-            and ~(self.period is None)
-            and (len(self.y) > 2 * self.period)
-        ):
-            self.seasonal_bool = True
-            # remove seasonality and compute the required h-step ahead seasonal components
-            trend, seasonal, self.seasonal_forecasts = remove_seasonality(
-                self.y, self.h, self.period
-            )
-            self.y_tilde = self.y_tilde - seasonal
+        if self.period is not None:
+            if (
+                (seasonality_test(self.y, self.period))
+                and ~(self.period is None)
+                and (len(self.y) > 2 * self.period)
+            ):
+                self.seasonal_bool = True
+                # remove seasonality and compute the required h-step ahead seasonal components
+                trend, seasonal, self.seasonal_forecasts = remove_seasonality(
+                    self.y, self.h, self.period
+                )
+                self.y_tilde = self.y_tilde - seasonal
 
         # create X data matrix as 3 lags of y
         X_train, y_train = split_into_train(self.y_tilde, lags=self.input_size)
@@ -207,8 +207,11 @@ class MLP_M4_benchmark(ForecastModel):
             learning_rate="adaptive",
             learning_rate_init=0.001,
             random_state=42,
-        )  # raises some convergence warnings
-        self.model.fit(X_train, y_train)
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.model.fit(X_train, y_train)
+
         self.resids = (
             self.model.predict(X_train) - y_train
         )  # training sample residuals
@@ -288,9 +291,9 @@ class RNN_M4_benchmark(ForecastModel):
     name = "RNN"
     method = "RNN M4 Competition Benchmark"
 
-    def __init__(self, h=1, level=[]):
+    def __init__(self, h=1, level=[], period=None):
         self.input_size = 3  # number of inputs to the forecasting model (lags of the time series)
-        super().__init__(h, level)
+        super().__init__(h, level, period)
 
     def description(self):
         return self.method
@@ -311,17 +314,18 @@ class RNN_M4_benchmark(ForecastModel):
             self.y_tilde[i] = self.y_tilde[i] - ((self.a * i) + self.b)
 
         self.seasonal_bool = False
-        if (
-            (seasonality_test(self.y, self.period))
-            and ~(self.period is None)
-            and (len(self.y) > 2 * self.period)
-        ):
-            self.seasonal_bool = True
-            # remove seasonality and compute the required h-step ahead seasonal components
-            trend, seasonal, self.seasonal_forecasts = remove_seasonality(
-                self.y, self.h, self.period
-            )
-            self.y_tilde = self.y_tilde - seasonal
+        if self.period is not None:
+            if (
+                (seasonality_test(self.y, self.period))
+                and ~(self.period is None)
+                and (len(self.y) > 2 * self.period)
+            ):
+                self.seasonal_bool = True
+                # remove seasonality and compute the required h-step ahead seasonal components
+                trend, seasonal, self.seasonal_forecasts = remove_seasonality(
+                    self.y, self.h, self.period
+                )
+                self.y_tilde = self.y_tilde - seasonal
 
         # create X data matrix as input_size lags of y
         X_train, y_train = split_into_train(self.y_tilde, lags=self.input_size)
@@ -352,7 +356,8 @@ class RNN_M4_benchmark(ForecastModel):
         opt = RMSprop(learning_rate=0.001)
         early_stop_callback = tf.keras.callbacks.EarlyStopping(
             monitor="loss", patience=3, verbose=0
-        )  # callback to allow early stopping of training is loss does not keep improving
+        )  # callback to allow early stopping of training if loss does not keep improving
+
         self.model.compile(loss="mean_squared_error", optimizer=opt)
 
         # fit the model to the training data
@@ -446,9 +451,9 @@ class RModel(ForecastModel, ABC):
 
     forecast_model_params = {}
 
-    def __init__(self, h=1, level=[]):
+    def __init__(self, h=1, level=[], period=None):
 
-        super().__init__(h, level)
+        super().__init__(h, level, period)
 
         import rpy2.robjects as robjects
         from rpy2.robjects import pandas2ri
@@ -480,11 +485,6 @@ class RModel(ForecastModel, ABC):
         pass
 
     def fit(self, y):
-
-        # Find period of y
-        freq = getattr(self.y.index, "inferred_freq", None)
-        self.period = freq_to_period(freq)
-
         r_forecast_dict = self.get_r_forecast_dict()
 
         self.method = r_forecast_dict["method"][0]

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -23,11 +23,11 @@ from sklearn.metrics import mean_absolute_error
 from sklearn.utils.validation import indexable, _num_samples
 from statsmodels.tsa.tsatools import freq_to_period
 
-#number of forecasts to make for series with different frequencies
-    #monthly data (freq = 12): 18 forecasts
-    #quarterly data (freq = 4): 8 forecasts
-    #weekly data (freq = 52): 13 forecasts
-forecast_len = {52:13, 12:18, 4:8} 
+# number of forecasts to make for series with different frequencies
+# monthly data (freq = 12): 18 forecasts
+# quarterly data (freq = 4): 8 forecasts
+# weekly data (freq = 52): 13 forecasts
+forecast_len = {52: 13, 12: 18, 4: 8}
 p_to_use = 1
 level = [50, 75, 95]
 
@@ -270,7 +270,7 @@ def run_job(job_dict, cv, model_params):
         forecast_dict,
         first_value,
         first_time,
-        model_params['h'],
+        model_params["h"],
         levels=level,
     )
 
@@ -303,7 +303,7 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
     job_list = []
     cv_instance_list = []
     model_params_list = []
-    
+
     # Parse JSON and cache
     for data_source_dict in data_sources_list:
 
@@ -323,12 +323,14 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
             series_df.index = series_df.index + offset
 
         all_forecasts = {}
-        
+
         # Find period of the series and define the TimeSeriesRollingSplit instance
         series_freq = getattr(series_df.index, "inferred_freq", None)
         series_period = freq_to_period(series_freq)
         series_h = forecast_len[series_period]
-        series_cv = TimeSeriesRollingSplit(h=series_h, p_to_use=p_to_use) #seperate TimeSeriesRollingSplit instance for each series to account for differences in frequencies
+        series_cv = TimeSeriesRollingSplit(
+            h=series_h, p_to_use=p_to_use
+        )  # seperate TimeSeriesRollingSplit instance for each series to account for differences in frequencies
 
         for model_class in model_class_list:
 
@@ -368,7 +370,11 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
 
     pool = Pool(cpu_count())
     results = pool.starmap(
-        run_job, [[job_list[i], cv_instance_list[i], model_params_list[i]] for i in range(len(job_list))]
+        run_job,
+        [
+            [job_list[i], cv_instance_list[i], model_params_list[i]]
+            for i in range(len(job_list))
+        ],
     )
 
     # Insert results of jobs into dictionary

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -360,7 +360,9 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
                 # Add CV instance to list
                 cv_instance_list.append(series_cv)
                 # Add model parameters dictionary to list
-                model_params_list.append({"h": series_h, "level": level, "period": series_period})
+                model_params_list.append(
+                    {"h": series_h, "level": level, "period": series_period}
+                )
 
                 # Temporarily set result to empty
                 result = {}

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -33,16 +33,16 @@ p_to_use = 1
 level = [50, 75, 95]
 
 model_class_list = [
-    # RNaive,
-    # RAutoARIMA,  # RAutoARIMA is very slow!
-    # RSimple,
-    # RHolt,
-    # RDamped,
-    # RTheta,
-    # RNaive2,
-    # RComb,
+    RNaive,
+    RAutoARIMA,  # RAutoARIMA is very slow!
+    RSimple,
+    RHolt,
+    RDamped,
+    RTheta,
+    RNaive2,
+    RComb,
     MLP_M4_benchmark,
-    # RNN_M4_benchmark,
+    RNN_M4_benchmark,
 ]
 
 

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -23,8 +23,12 @@ from sklearn.metrics import mean_absolute_error
 from sklearn.utils.validation import indexable, _num_samples
 from statsmodels.tsa.tsatools import freq_to_period
 
+#number of forecasts to make for series with different frequencies
+    #monthly data (freq = 12): 18 forecasts
+    #quarterly data (freq = 4): 8 forecasts
+    #weekly data (freq = 52): 13 forecasts
+forecast_len = {52:13, 12:18, 4:8} 
 p_to_use = 1
-forecast_len = 8
 level = [50, 75, 95]
 
 model_class_list = [
@@ -266,7 +270,7 @@ def run_job(job_dict, cv, model_params):
         forecast_dict,
         first_value,
         first_time,
-        forecast_len,
+        model_params['h'],
         levels=level,
     )
 
@@ -297,7 +301,9 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
     series_dict = {}
 
     job_list = []
-
+    cv_instance_list = []
+    model_params_list = []
+    
     # Parse JSON and cache
     for data_source_dict in data_sources_list:
 
@@ -317,6 +323,12 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
             series_df.index = series_df.index + offset
 
         all_forecasts = {}
+        
+        # Find period of the series and define the TimeSeriesRollingSplit instance
+        series_freq = getattr(series_df.index, "inferred_freq", None)
+        series_period = freq_to_period(series_freq)
+        series_h = forecast_len[series_period]
+        series_cv = TimeSeriesRollingSplit(h=series_h, p_to_use=p_to_use) #seperate TimeSeriesRollingSplit instance for each series to account for differences in frequencies
 
         for model_class in model_class_list:
 
@@ -337,6 +349,10 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
                         "downloaded_dict": downloaded_dict,
                     }
                 )
+                # Add CV instance to list
+                cv_instance_list.append(series_cv)
+                # Add model parameters dictionary to list
+                model_params_list.append({"h": series_h, "level": level})
 
                 # Temporarily set result to empty
                 result = {}
@@ -350,13 +366,9 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
             "all_forecasts": all_forecasts,
         }
 
-    cv = TimeSeriesRollingSplit(h=forecast_len, p_to_use=p_to_use)
-    model_params = {"h": forecast_len, "level": level}
-
     pool = Pool(cpu_count())
-
     results = pool.starmap(
-        run_job, [[job_dict, cv, model_params] for job_dict in job_list]
+        run_job, [[job_list[i], cv_instance_list[i], model_params_list[i]] for i in range(len(job_list))]
     )
 
     # Insert results of jobs into dictionary

--- a/updater/update.py
+++ b/updater/update.py
@@ -3,20 +3,23 @@ from run_models import run_models
 import os
 import shutil
 
-print("Downloading Data")
-download_data("../shared_config/data_sources.json", "../data/downloads")
+if __name__ == "__main__":
 
-print("Running Models")
-run_models(
-    "../shared_config/data_sources.json",
-    "../data/downloads",
-    "../data/forecasts",
-)
+    # print("Downloading Data")
+    # download_data("../shared_config/data_sources.json", "../data/downloads")
 
-print("Clearing Cache")
-for filename in os.listdir("/nginx_cache"):
-    filepath = os.path.join("/nginx_cache", filename)
-    try:
-        shutil.rmtree(filepath)
-    except OSError:
-        os.remove(filepath)
+    print("Running Models")
+    run_models(
+        "../shared_config/data_sources.json",
+        "../data/downloads",
+        "../data/forecasts",
+    )
+
+    if os.path.isdir("/nginx_cache"):
+        print("Clearing Cache")
+        for filename in os.listdir("/nginx_cache"):
+            filepath = os.path.join("/nginx_cache", filename)
+            try:
+                shutil.rmtree(filepath)
+            except OSError:
+                os.remove(filepath)


### PR DESCRIPTION
# Summary

The number of forecasts is now dependent on the frequency of the underlying time series:

monthly data (freq = 12): 18 forecasts
quarterly data (freq = 4): 8 forecasts
weekly data (freq = 52): 13 forecasts

The forecast_len variable is a dictionary with keys that are the frequency of the series and values that are the number of forecasts to make. The currently implemented horizons are described in the methodology page.

# Related Issues

N/A

# Checklist
  - [x] The change is tested and works locally.
  - [x] All related issues are referenced.
  - [ ] Blog post included in PR if required e.g. new feature.
