### PR TITLE
Faster ML benchmarks

### DIFF
--- a/updater/models.py
+++ b/updater/models.py
@@ -153,14 +153,13 @@ class ForecastModel(BaseEstimator, ABC):
     def predict(self):
         pass
 
-
-class MLP_M4_benchmark(ForecastModel):
+class LinearRegressionForecast(ForecastModel):
     """
-    Multi-layer preceptron model from the M4 forecasting competition benchmarks
+    Linear regression model from the M4 forecasting competition benchmarks
     """
 
-    name = "MLP"
-    method = "MLP M4 Competition Benchmark"
+    name = "Linear Regression"
+    method = "Linear Regression"
 
     def __init__(self, h=1, level=[], period=None):
         self.input_size = 3  # number of inputs to the forecasting model (lags of the time series)
@@ -199,18 +198,11 @@ class MLP_M4_benchmark(ForecastModel):
         X_train = X_train.values
         y_train = y_train.values
 
-        self.model = MLPRegressor(
-            hidden_layer_sizes=6,
-            activation="identity",
-            solver="adam",
-            max_iter=100,
-            learning_rate="adaptive",
-            learning_rate_init=0.001,
-            random_state=42,
-        )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.model.fit(X_train, y_train)
+        from sklearn.linear_model import LinearRegression
+
+        self.model = LinearRegression()
+
+        self.model.fit(X_train, y_train)
 
         self.resids = (
             self.model.predict(X_train) - y_train
@@ -281,7 +273,6 @@ class MLP_M4_benchmark(ForecastModel):
             forecast_dict[f"UB_{self.level[i]}"] = upper_CI
 
         return forecast_dict
-
 
 class RNN_M4_benchmark(ForecastModel):
     """

--- a/updater/models.py
+++ b/updater/models.py
@@ -153,6 +153,7 @@ class ForecastModel(BaseEstimator, ABC):
     def predict(self):
         pass
 
+
 class LinearRegressionForecast(ForecastModel):
     """
     Linear regression model from the M4 forecasting competition benchmarks
@@ -273,6 +274,7 @@ class LinearRegressionForecast(ForecastModel):
             forecast_dict[f"UB_{self.level[i]}"] = upper_CI
 
         return forecast_dict
+
 
 class RNN_M4_benchmark(ForecastModel):
     """

--- a/updater/requirements.txt
+++ b/updater/requirements.txt
@@ -3,5 +3,6 @@ requests
 rpy2
 scikit-learn
 statsmodels
-tensorflow
+torch
+torch
 tzlocal

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -16,8 +16,8 @@ from models import (
     RTheta,
     RNaive2,
     RComb,
-    MLP_M4_benchmark,
     RNN_M4_benchmark,
+    LinearRegressionForecast
 )
 from sklearn.metrics import mean_absolute_error
 from sklearn.utils.validation import indexable, _num_samples
@@ -41,8 +41,8 @@ model_class_list = [
     RTheta,
     RNaive2,
     RComb,
-    MLP_M4_benchmark,
     RNN_M4_benchmark,
+    LinearRegressionForecast,
 ]
 
 

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -16,8 +16,8 @@ from models import (
     RTheta,
     RNaive2,
     RComb,
-    RNN_M4_benchmark,
     LinearRegressionForecast,
+    RNN_M4_benchmark,
 )
 from sklearn.metrics import mean_absolute_error
 from sklearn.utils.validation import indexable, _num_samples
@@ -34,15 +34,15 @@ level = [50, 75, 95]
 
 model_class_list = [
     RNaive,
-    RAutoARIMA,  # RAutoARIMA is very slow!
+    RAutoARIMA,
     RSimple,
     RHolt,
     RDamped,
     RTheta,
     RNaive2,
     RComb,
-    RNN_M4_benchmark,
     LinearRegressionForecast,
+    RNN_M4_benchmark,
 ]
 
 

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -17,7 +17,7 @@ from models import (
     RNaive2,
     RComb,
     RNN_M4_benchmark,
-    LinearRegressionForecast
+    LinearRegressionForecast,
 )
 from sklearn.metrics import mean_absolute_error
 from sklearn.utils.validation import indexable, _num_samples


### PR DESCRIPTION
# Summary

Attempting to replace the MLP and RNN benchmarks with faster alternatives.

Following substitutions have been made:
- MLP -> Linear Regression
- RNN (keras) -> RNN (pytorch)

# Related Issues

- https://github.com/forecastlab/forecast_dash/issues/96

# Checklist
  - [X] The change is tested and works locally.
  - [X] All related issues are referenced.
  - [X] Blog post included in PR if required e.g. new feature.