### PR TITLE
Fix sqrt warning

### DIFF
--- a/updater/models.py
+++ b/updater/models.py
@@ -50,7 +50,7 @@ def seasonality_test(original_ts, ppy):
     for i in range(2, ppy):
         s = s + (acf(original_ts, i) ** 2)
 
-    limit = 1.645 * (np.sqrt((1 + 2 * (s**2)) / len(original_ts)))
+    limit = 1.645 * (np.sqrt((1 + 2 * (s ** 2)) / len(original_ts)))
 
     return (abs(acf(original_ts, ppy))) > limit
 

--- a/updater/models.py
+++ b/updater/models.py
@@ -50,7 +50,7 @@ def seasonality_test(original_ts, ppy):
     for i in range(2, ppy):
         s = s + (acf(original_ts, i) ** 2)
 
-    limit = 1.645 * (np.sqrt((1 + 2 * s) / len(original_ts)))
+    limit = 1.645 * (np.sqrt((1 + 2 * (s**2)) / len(original_ts)))
 
     return (abs(acf(original_ts, ppy))) > limit
 


### PR DESCRIPTION
# Summary 

The seasonality test sqrt issue was caused by not squaring the ACF function. In the python version of the M4 benchmark code. The R version of the M4 benchmark code does square the ACF function and this is mentioned in the M4 python code benchmark file.

# Related Issues

List any related issues here. Write NA if no related issues.

# Checklist
  - [x] The change is tested and works locally.
  - [x] All related issues are referenced.
  - [ ] Blog post included in PR if required e.g. new feature.
