### PR TITLE
Clickable map to relevant search page

### DIFF
--- a/dash/pages/home.py
+++ b/dash/pages/home.py
@@ -73,13 +73,17 @@ def _featured_latest_news(feature_series_title):
                         ),
                         # html.A(
                         #     [
-                                html.Div(dcc.Graph(
-                                    figure=world_map_of_forecasts(),
-                                    config={"displayModeBar": False}, id='choropleth',
-                                ), id = 'myDiv'),
-                                html.Div(id='LinkOutCountry')
-                            # ],
-                            # href="/search/",
+                        html.Div(
+                            dcc.Graph(
+                                figure=world_map_of_forecasts(),
+                                config={"displayModeBar": False},
+                                id="choropleth",
+                            ),
+                            id="myDiv",
+                        ),
+                        html.Div(id="LinkOutCountry")
+                        # ],
+                        # href="/search/",
                         # ),
                     ],
                     lg=8,
@@ -127,21 +131,27 @@ def _featured_latest_news(feature_series_title):
 
 
 @callback(
-    Output('LinkOutCountry', 'children'),
-    [Input('choropleth', 'clickData')])
+    Output("LinkOutCountry", "children"), [Input("choropleth", "clickData")]
+)
 def update_figure(clickData):
     countries = pd.read_csv("../data/CountriesList.csv")
 
-    if clickData is not None:            
-        location = clickData['points'][0]['location']
-        selection = countries['Country'][countries['Code'] ==location].values[0]
+    if clickData is not None:
+        location = clickData["points"][0]["location"]
+        selection = countries["Country"][countries["Code"] == location].values[
+            0
+        ]
 
         # if location not in selections:
         #     selections.add(location)
         # else:
         #     selections.remove(location)
-        
-    return html.A([f"Check out the forecast series in the {selection}"],href = f"search/?name={selection}")
+
+    return html.A(
+        [f"Check out the forecast series in the {selection}"],
+        href=f"search/?name={selection}",
+    )
+
 
 def _leaderboard():
     return dbc.Row(

--- a/dash/pages/home.py
+++ b/dash/pages/home.py
@@ -77,7 +77,7 @@ def _featured_latest_news(feature_series_title):
                                     figure=world_map_of_forecasts(),
                                     config={"displayModeBar": False}, id='choropleth',
                                 ), id = 'myDiv'),
-                                html.Div(id='TEST')
+                                html.Div(id='LinkOutCountry')
                             # ],
                             # href="/search/",
                         # ),
@@ -127,7 +127,7 @@ def _featured_latest_news(feature_series_title):
 
 
 @callback(
-    Output('TEST', 'children'),
+    Output('LinkOutCountry', 'children'),
     [Input('choropleth', 'clickData')])
 def update_figure(clickData):
     countries = pd.read_csv("../data/CountriesList.csv")
@@ -141,18 +141,7 @@ def update_figure(clickData):
         # else:
         #     selections.remove(location)
         
-    return f"outputinng the follow: {selection}"
-
-# clientside_callback(
-#     """
-#     async function(clickData) {
-#     # location = clickData['points'][0]['location']
-#     window.open('www.google.com')
-#     }
-#     """,
-#     Output('TEST', 'children'),
-#     Input('choropleth', 'clickData'),
-# )
+    return html.A([f"Check out the forecast series in the {selection}"],href = f"search/?name={selection}")
 
 def _leaderboard():
     return dbc.Row(

--- a/dash/pages/home.py
+++ b/dash/pages/home.py
@@ -1,11 +1,12 @@
 ### dash related
-from dash import html, dcc
+from dash import html, dcc, callback, Output, Input
 import dash
 import dash_bootstrap_components as dbc
 
 from urllib.parse import urlencode
 
 import json
+import pandas as pd
 
 ### utils
 from common import (
@@ -70,15 +71,16 @@ def _featured_latest_news(feature_series_title):
                             "World Map of Featured Series",
                             style={"text-align": "center"},
                         ),
-                        html.A(
-                            [
-                                dcc.Graph(
+                        # html.A(
+                        #     [
+                                html.Div(dcc.Graph(
                                     figure=world_map_of_forecasts(),
-                                    config={"displayModeBar": False},
-                                )
-                            ],
-                            href="/search/",
-                        ),
+                                    config={"displayModeBar": False}, id='choropleth',
+                                ), id = 'myDiv'),
+                                html.Div(id='TEST')
+                            # ],
+                            # href="/search/",
+                        # ),
                     ],
                     lg=8,
                 ),
@@ -123,6 +125,34 @@ def _featured_latest_news(feature_series_title):
         ),
     ]
 
+
+@callback(
+    Output('TEST', 'children'),
+    [Input('choropleth', 'clickData')])
+def update_figure(clickData):
+    countries = pd.read_csv("../data/CountriesList.csv")
+
+    if clickData is not None:            
+        location = clickData['points'][0]['location']
+        selection = countries['Country'][countries['Code'] ==location].values[0]
+
+        # if location not in selections:
+        #     selections.add(location)
+        # else:
+        #     selections.remove(location)
+        
+    return f"outputinng the follow: {selection}"
+
+# clientside_callback(
+#     """
+#     async function(clickData) {
+#     # location = clickData['points'][0]['location']
+#     window.open('www.google.com')
+#     }
+#     """,
+#     Output('TEST', 'children'),
+#     Input('choropleth', 'clickData'),
+# )
 
 def _leaderboard():
     return dbc.Row(


### PR DESCRIPTION
# Summary

Using callbacks, create a link out to the relevant search page. Not test locally, assumes that the search via url component has been fixed. 

# Related Issues

Address #173 
# Checklist
  - [ ] The change is tested and works locally.
  - [x] All related issues are referenced.
  - [ ] Blog post included in PR if required e.g. new feature.
