### PR TITLE
Fix leaderboard not loading #219

### DIFF
--- a/dash/common.py
+++ b/dash/common.py
@@ -694,10 +694,14 @@ def get_leaderboard_df(series_list, CV_score_function="MSE"):
     chosen_methods = []
 
     for series_title, forecast_data in forecast_series_dicts.items():
-        model_name = select_best_model(
-            forecast_data, CV_score_function=CV_score_function
-        )
-        chosen_methods.append(model_name)
+        try:
+            model_name = select_best_model(
+                forecast_data, CV_score_function=CV_score_function
+            )
+            chosen_methods.append(model_name)
+        except Exception as e:
+            print(f'{[series_title]} had the following error: {e}') # Usually missing forecasts
+            pass
 
     stats_raw = pd.DataFrame({"Method": chosen_methods})
 

--- a/dash/pages/leaderboard.py
+++ b/dash/pages/leaderboard.py
@@ -79,6 +79,9 @@ def update_leaderboard_df(CV_score):
     construct the best model leaderboard based upon user selected scoring function
     """
     # Build leaderboard with chosen CV scoring function
+    data_sources_json_file = open("../shared_config/data_sources.json")
+    series_list = json.load(data_sources_json_file)
+
     counts = get_leaderboard_df(series_list, CV_score)
 
     win_proportion = (


### PR DESCRIPTION
# Summary

Missing series load, and handling of nonetype for no forecasts.

# Related Issues
Fixing the leader board #219

# Checklist
  - [x] The change is tested and works locally.
  - [x] All related issues are referenced.
  - [x] Blog post included in PR if required e.g. new feature.
